### PR TITLE
Clarify registration styles, livestream vs zoom

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -27,17 +27,21 @@ interactivity - register with a friend!  If you feel a bit more
 confident in the material, you can [register as an exercise
 leader](volunteer/).
 
-The workshop will be held online.
+The workshop will be held online, see options at [how to
+joining](join/).
 
-* You can attend by registering and
-  receiving the Zoom link, which lets you take part in teams and
-  breakout rooms. (limited places)
-
-* Anyone may also attend via the livestream at
-  [twitch.tv/coderefinery](https://twitch.tv/coderefinery).  If you
+* Everyone watches the main teaching via a livestream at
+  <https://twitch.tv/coderefinery>.  If you
   register, you can get emails and link to ask questions.
 
-**Before signing** up please also read
+* You can also register to attend Zoom breakout rooms (limited
+  places).  Please only register for Zoom if you want to actively take
+  part in the exercises; we will arrange participants into small
+  interactive breakout rooms.
+
+* Some partners offer in-person breakout rooms and help, see below.
+
+**Before signing up** please also read
 [this privacy note about tools/services we use](requirements/#privacy-and-tools-online-services).
 
 

--- a/content/join.md
+++ b/content/join.md
@@ -4,13 +4,20 @@ title = "How to join"
 
 ## How to join
 
-We are normally limited by number of expert helpers and individual exercise leaders, thus we have two options:
+We are normally limited by number of expert helpers and individual
+exercise leaders, so we use a livestream to reach more people.  Anyone
+may watch the livestream (<https://twitch.tv/coderefinery>), and we
+have Zoom for breakout sessions up to our capacity.  Some partners may
+even host in-person breakout rooms.  Read more about [how to attend a
+livestream
+course](https://coderefinery.github.io/manuals/how-to-attend-stream/).
 
-### Zoom registration
+### Attend via livestream + Zoom
 
-In Zoom, we group attendees into teams, with an exercise leader.  This
-is a very interactive workshop.
+In Zoom, we group attendees into teams, with an exercise leader and
+help from our expert helpers.  This is a very interactive workshop.
 
+- Register as type **Learner** or **Exercise leader**
 - Anyone may register as a learner, we will try to take as many as we can.
 - Complete teams are preferred: one exercise leader and 4-6 learners:
   - Everyone on the team must register separately.
@@ -24,9 +31,11 @@ is a very interactive workshop.
     and prepare for the future together. If you will work together later,
     learning the tools at the same time is a great way to do it.
 - If you routinely use Git and know Python somewhat well or you've been to
-  a CodeRefinery before, you are definitely capable of being an exercise leader and register as one!
+  a CodeRefinery before, you are definitely capable of being an exercise leader!
 
-### Attend via live stream
+### Attend via livestream only
+
+- Register as type **Livestream only**
 
 The promise of the Internet is that we can reach everyone, so why
 don't we?  So, we have a live stream
@@ -35,12 +44,13 @@ that anyone may attend
 the workshop, even if we don't have resources to provide interactive
 breakout rooms.  The live stream option is also good if you want to
 passively see what we are talking about, but don't want to take an
-interactive Zoom seat.
+interactive Zoom seat.  **Please register anyway so that you can get
+emails and we can report our impact**, but you do not have to.
 
-Breakout rooms are not streamed, you'll do exercises by yourself.
-We'll often go over the exercises on stream, though.  You *will* be
-able to ask us questions, and we recommend that you form your own team and do
-exercises together.  We will support this as much as we can!
+**We recommend that you form your own team and do
+exercises together in your own breakout room (in-person or online)**.
+We will support this as much as we can!  You *will* be
+able to ask us questions if you register.
 
 
 

--- a/content/requirements.md
+++ b/content/requirements.md
@@ -14,8 +14,10 @@ title = "Prerequisites and software requirements"
   the basics anyway, but please go through
   [this Git-refresher material](https://coderefinery.github.io/git-refresher/)
   for a basic overview and important configuration steps.
+- Read [how to attend a livestream
+  course](https://coderefinery.github.io/manuals/how-to-attend-stream/).
 
-## Preparation
+## Preparation (software insallation)
 
 - You need to install some software **before the workshop starts**.
   Please follow the instructions and checklist on


### PR DESCRIPTION
- Make livestream more equal to Zoom in terms of registration, since
  it's not the top-level way to attend.  Generally revise a lot of the
  text around this.
- Review: worth a read, automerge 3days
