### PR TITLE
content/join: Add "Partner universities" as first priority for registration

### DIFF
--- a/content/join.md
+++ b/content/join.md
@@ -51,10 +51,11 @@ Collaboration](https://neic.no/).
 
 When we have more sign-ups as **individual learners** than our capacity allows, the following priority criteria apply:
 
-1. National universities or research institutes in Nordic countries and Estonia
-2. Private companies and government agencies in Nordic countries or Estonia
-3. European national universities or research institutes from outside the Nordics.
-4. Others
+1. Partner universities
+2. National universities or research institutes in Nordic countries and Estonia
+3. Private companies and government agencies in Nordic countries or Estonia
+4. European national universities or research institutes from outside the Nordics.
+5. Others
 
 Therefore it is very important that you use an email address
 corresponding to your affiliation.  If you aren't accepted to the Zoom


### PR DESCRIPTION
- I'm not sure if this is a good phrasing, so think carefully
- State first priority for partners, that is, those who are
  contributing their own resources to run the workshop.
- This seems to be a reasonable thing to do to join universities to
  join as partners.  But project-wise is this a good thing to say?  In
  practice I think that the partners will rarely fill up the workshop
  (and in practice, the partners represent the countries, so... 1 is
  almost the same as 2).
- Review: detailed consideration of what this means.
