### PR TITLE
content/join: Revise the joining instructions

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -28,16 +28,16 @@ confident in the material, you can [register as an exercise
 leader](volunteer/).
 
 The workshop will be held online, see options at [how to
-joining](join/).
+join](join/):
 
 * Everyone watches the main teaching via a livestream at
   <https://twitch.tv/coderefinery>.  If you
   register, you can get emails and link to ask questions.
 
-* You can also register to attend Zoom breakout rooms (limited
-  places).  Please only register for Zoom if you want to actively take
-  part in the exercises; we will arrange participants into small
-  interactive breakout rooms.
+* You can also register to attend our Zoom breakout rooms (limited
+  places), and you will be placed into a small, interactive breakout
+  room.  Please only register for Zoom if you want to actively take
+  part in the exercises. ([read more](join/))
 
 * Some partners offer in-person breakout rooms and help, see below.
 

--- a/content/join.md
+++ b/content/join.md
@@ -12,45 +12,90 @@ even host in-person breakout rooms.  Read more about [how to attend a
 livestream
 course](https://coderefinery.github.io/manuals/how-to-attend-stream/).
 
-### Attend via livestream + Zoom
-
-In Zoom, we group attendees into teams, with an exercise leader and
-help from our expert helpers.  This is a very interactive workshop.
-
-- Register as type **Learner** or **Exercise leader**
-- Anyone may register as a learner, we will try to take as many as we can.
-- Complete teams are preferred: one exercise leader and 4-6 learners:
-  - Everyone on the team must register separately.
-  - Decide on a team name, and provide it when registering,
-    so that we can link teammates together.
-  - During the exercise sessions in breakout rooms, the exercise leader has
-    primary responsibility for their group's hands-on exercises.
-    Still, instructors/expert helpers drop by to check and help
-    as needed, so don't worry if as an exercise leader you don't know everything.
-  - This is a great opportunity to bring your friends and colleagues
-    and prepare for the future together. If you will work together later,
-    learning the tools at the same time is a great way to do it.
-- If you routinely use Git and know Python somewhat well or you've been to
-  a CodeRefinery before, you are definitely capable of being an exercise leader!
-
 ### Attend via livestream only
 
-- Register as type **Livestream only**
-
 The promise of the Internet is that we can reach everyone, so why
-don't we?  So, we have a live stream
-([twitch.tv/coderefinery](https://twitch.tv/coderefinery)) option so
-that anyone may attend
-the workshop, even if we don't have resources to provide interactive
-breakout rooms.  The live stream option is also good if you want to
-passively see what we are talking about, but don't want to take an
-interactive Zoom seat.  **Please register anyway so that you can get
-emails and we can report our impact**, but you do not have to.
+don't we?  We teach on a Twitch livestream
+([twitch.tv/coderefinery](https://twitch.tv/coderefinery)) so that
+anyone may attend the workshop.  With livestream attendance, you get:
+- All workshop content, text and video.
+- Videos released the same day.
+- Ability to ask questions, if you register.
+- Ability to do exercises yourself, or in a self-organized group.
 
-**We recommend that you form your own team and do
-exercises together in your own breakout room (in-person or online)**.
-We will support this as much as we can!  You *will* be
-able to ask us questions if you register.
+Attendees report a great experience with these livestream courses!
+**We recommend that you form your own team and do exercises together
+in your own breakout room (in-person or online)**.  We will support
+this as much as we can!  You *will* be able to ask us questions if you
+register.
+
+**Please register anyway so that you can get emails and we can better
+report our impact** (but you don't have to).
+
+
+
+### Attend via livestream + Zoom
+
+To provide interactive support, we also host parallel a Zoom session.
+Learners watch the livestream during teaching, and work in Zoom during
+exercises.
+
+In Zoom, we group attendees into teams with an exercise leaders and
+help from our staff.  This makes a very interactive workshop, but
+unfortunately we have limited resources to accept these
+registrations.
+
+- Register as type ``Zoom Learner`` or ``Zoom Exercise leader``
+- You may register as a **solo learner**, we'll try to take as many as
+  we can (up to the number of exercise leaders who volunteer)
+- If a **team** registers with their own exercise leader, you get
+  priority and we will try to accept the whole team.  Everyone on the
+  team should register separately and set the same `Team name` in the
+  registration.
+
+Attending via Zoom will give you everything the livestream does, with
+the possibly of centrally organized teams and a bit more help.
+
+
+
+### FAQ: how should I register?
+
+- **I am alone and want to work with others, how should I register?**
+  - Register for Zoom (if we are full you get the livestream anyway)
+- **Why teams?**
+  - People learn best in small groups, even if the primary teaching
+    sessions can reach many people and be effective.  Our strategy
+    gives us the best of both worlds.
+- **I am making my own team, how should I register?**
+  - **Want more personal support:** `Zoom` you will have more
+    support from our expert helpers, which may be good for less
+    confident teams.
+  - **Want to manage everything yourself** (for example make your own
+    Zoom or in-person room): `Livestream only`.  The coordinator can
+    still join our CodeRefinery chat and interact with us.
+  - The coordinator could register on behalf of your team and forward
+    information to the others.
+- **My complete team will work together in a physical room, is there
+  any point to joining your Zoom?**
+  - Expert helpers will drop by the Zoom breakout room and ask if
+    things are going OK.  If you won't want to screenshare with them
+    and see their demos, there is probably no point.  (Note that Zoom
+    is still useful in the physical room for screensharing with each
+    other).
+- **I want to make my a team on my own, do I need to register?  Does
+  everyone on the team need to register?**
+  - Technically you don't have to, if you carefully check the website
+    for news.
+  - We prefer if you register so that we can report our impact better.
+    Also, the team gets emails direct from us and the HackMD links to
+    ask questions.
+- **I'm an organization or group, I want to sponsor my community's teams!**
+  - Great!  You can do this with our without communicating with us.
+    Feel free to just make your own registration form and manage it if
+    you want.  Or talk with us organize them in our central Zoom.
+    [Read more about local breakout
+    rooms](https://coderefinery.github.io/manuals/local-breakout-rooms/)
+    and [contact us](https://coderefinery.github.io/manuals/chat/).
 
 
 
@@ -61,7 +106,7 @@ Collaboration](https://neic.no/).
 
 When we have more sign-ups as **individual learners** than our capacity allows, the following priority criteria apply:
 
-1. Partner universities
+1. Partner communities
 2. National universities or research institutes in Nordic countries and Estonia
 3. Private companies and government agencies in Nordic countries or Estonia
 4. European national universities or research institutes from outside the Nordics.

--- a/content/join.md
+++ b/content/join.md
@@ -92,7 +92,7 @@ the possibly of centrally organized teams and a bit more help.
 - **I'm an organization or group, I want to sponsor my community's teams!**
   - Great!  You can do this with or without communicating with us.
     Feel free to just make your own registration form and manage it if
-    you want.  Or talk with us organize them in our central Zoom.
+    you want.  Or talk with us organize them as part of our centrally organized Zoom.
     [Read more about local breakout
     rooms](https://coderefinery.github.io/manuals/local-breakout-rooms/)
     and [contact us](https://coderefinery.github.io/manuals/chat/).

--- a/content/join.md
+++ b/content/join.md
@@ -82,7 +82,7 @@ the possibly of centrally organized teams and a bit more help.
     and see their demos, there is probably no point.  (Note that Zoom
     is still useful in the physical room for screensharing with each
     other).
-- **I want to make my a team on my own, do I need to register?  Does
+- **I want to make my team on my own, do I need to register?  Does
   everyone on the team need to register?**
   - Technically you don't have to, if you carefully check the website
     for news.
@@ -90,7 +90,7 @@ the possibly of centrally organized teams and a bit more help.
     Also, the team gets emails direct from us and the HackMD links to
     ask questions.
 - **I'm an organization or group, I want to sponsor my community's teams!**
-  - Great!  You can do this with our without communicating with us.
+  - Great!  You can do this with or without communicating with us.
     Feel free to just make your own registration form and manage it if
     you want.  Or talk with us organize them in our central Zoom.
     [Read more about local breakout

--- a/content/join.md
+++ b/content/join.md
@@ -74,7 +74,7 @@ the possibly of centrally organized teams and a bit more help.
     Zoom or in-person room): `Livestream only`.  The coordinator can
     still join our CodeRefinery chat and interact with us.
   - The coordinator could register on behalf of your team and forward
-    information to the others.
+    information to the others (but it's nice if everyone registers, see below).
 - **My complete team will work together in a physical room, is there
   any point to joining your Zoom?**
   - Expert helpers will drop by the Zoom breakout room and ask if


### PR DESCRIPTION
- Based on chat feedback
- Emphasize livestream as the first option
- Say under what conditions you could join Zoom
- Move more of the description into a new FAQ section which tries to
  lay things out case-by-case
- Indico needs to rename 'Learner' to 'Zoom Learner' and same for
  exercise leader.
- Review: worth a read but also OK to merge and improve
