### PR TITLE
content/_index: Add currently signed up instructors and expert helpers

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -149,17 +149,23 @@ The schedule includes frequent breaks.
 #### Coordinators
 
 - Radovan Bast
-
-
-#### Host
-
-- Radovan Bast
+- Richard Darst
+- Enrico Glerean
 
 
 #### Instructors and expert helpers
 
 - Radovan Bast
-- TBA
+- Richard Darst
+- Enrico Glerean
+- Luca Ferranti
+- Johan Hellsvik
+- Diana Iusan
+- Jarno Rantaharju
+- Sabry Razick
+- Thor Wikfeldt
+- Samantha Wittke
+- and you?
 
 
 #### Exercise leaders :heart:


### PR DESCRIPTION
- I haven't asked any of these people if they can be listed, but I
  think most have in past workshops.
