### PR TITLE
Change links from cr.org to coderefinery.github.io

### DIFF
--- a/content/questions/day2.md
+++ b/content/questions/day2.md
@@ -79,7 +79,7 @@ What should we do differently today?
     - Refresh the page when needed.  Switch to edit mode once and then back.  But these aren't perfect, so if you notice lag let us know and we will make it shorter.
 
 2. Can you give a broad explanation about how git works? Inner dynamics, etc.
-    - You may check our ["under the hood lesson"](https://coderefinery.org/git-intro/under-the-hood/) that shows what happens in the .git/ directory as a result of different `git` commands.
+    - You may check our ["under the hood lesson"](https://coderefinery.github.io/git-intro/under-the-hood/) that shows what happens in the .git/ directory as a result of different `git` commands.
     - Great question. Maybe we can comment on this during start. It stores entire state of the project every time, but it does so very efficiently by storing the data in a tree structure, reusing existing data. It does not store differences. Differences are computed. Branches are pointers (a branch is a file with a 40-char string in it).
 
 
@@ -100,7 +100,7 @@ What should we do differently today?
 https://coderefinery.github.io/git-intro/
 
 ### 1.1 Sharing repositories online
-https://coderefinery.org/git-intro/remotes/
+https://coderefinery.github.io/git-intro/remotes/
 
 
 6. Does the name of online repository has to correspond to the local one?
@@ -324,7 +324,7 @@ https://coderefinery.org/git-intro/remotes/
 50. It might be good to notice that even if you change the repository from public to private it will not delete the forks if someone has forked it.
     
 ### 1.2 Inspecting history
-https://coderefinery.org/git-intro/archaeology/
+https://coderefinery.github.io/git-intro/archaeology/
 
 51. If one uses `git grep`, can we use extended regular expressions?
     - you can use regular expressions, not sure about extended regular expressions
@@ -422,7 +422,7 @@ https://coderefinery.org/git-intro/archaeology/
     - `git grep` only searches in files tracked by git, it may be significantly faster than `grep`
 
 68. Does `git log -S` only search in the commit messages or also within the documents?  
-    I refer to https://coderefinery.org/git-intro/archaeology/#git-log-s-to-search-through-the-history-of-changes and *While git grep searches the current state of the repository, it is also possible to search through all changes for “sometext”*
+    I refer to https://coderefinery.github.io/git-intro/archaeology/#git-log-s-to-search-through-the-history-of-changes and *While git grep searches the current state of the repository, it is also possible to search through all changes for “sometext”*
     - `git log -S` doesn't search commit messages, it searches in tracked files. Useful to find when a particular code line was introduced and/or removed
     - it is unfortunate that this look so similar to `git log` :| To me it suggests searching in the log (which is wrong!) +1
         - It returns commit messages, though!
@@ -507,7 +507,7 @@ https://coderefinery.org/git-intro/archaeology/
 
 82. How do I search when using git annotate?
     - Type `/`, then type the search term and press Enter
-    - also have a look here: https://coderefinery.org/git-intro/archaeology/#git-annotate-to-annotate-code-with-commit-metadata
+    - also have a look here: https://coderefinery.github.io/git-intro/archaeology/#git-annotate-to-annotate-code-with-commit-metadata
 
 
 83. Want to check which commands I have used with git and better yet save them for some future use (without duplicates)
@@ -624,21 +624,21 @@ https://coderefinery.org/git-intro/archaeology/
      - see #88, `git log -S` looks for changes in the exact matching string. And the search sring actually didn't change in the commits noted `git annotate` only additional things (spaces) in the line changed. 
 
 106. What webpage are we looking at right now?
-     - https://coderefinery.org/git-intro/recovering/
+     - https://coderefinery.github.io/git-intro/recovering/
 
 
 107. I am getting this error when i try to run "$ python get_pi.py"
-      - Either Python is not installed, or the terminal cannot find it. See installation instruction here: https://coderefinery.org/installation/conda/ and then https://coderefinery.org/installation/conda-environment/
+      - Either Python is not installed, or the terminal cannot find it. See installation instruction here: https://coderefinery.github.io/installation/conda/ and then https://coderefinery.github.io/installation/conda-environment/
         - Miniconda comes with Python, so installing it and creating an environment is enough to get Python.
             - I also get this error, but I have already miniconda installed.
-                - hopefully this helps: https://coderefinery.org/installation/conda/#setting-path-to-conda-from-your-terminal-shell
+                - hopefully this helps: https://coderefinery.github.io/installation/conda/#setting-path-to-conda-from-your-terminal-shell
 
 108. What if I stage, and then clean only the local repository? What will happen to the stagged?
      - staging essentially writes the changed files to the git database (creates object for them). But without being commited, they will not be part of any branch. So (but I'm not entirely certain), if you have used `git add file1` and then delete file 1 (not with `git rm` but with something outside git), you could recover the file or still commit it and it will be in the state that it was before you deleted it. If you `git add` it again after you deleted it, git will consider it as deleted and the next commit will contain a deletion of the file.
 
 
 ### 1.3 Undoing and recovering
-https://coderefinery.org/git-intro/recovering/
+https://coderefinery.github.io/git-intro/recovering/
 
 109. Does Staged mean commit? I forgot.
      - Stage means "added" i.e. `git add` stages a file for a commit.
@@ -666,7 +666,7 @@ https://coderefinery.org/git-intro/recovering/
         - Ok thanks, so that won't necessarily make a mess although the most recent commit might be dependent on changes made in the two previous commits?
 
 114. `Python was not found; run without arguments to install from the Microsoft Store, or disable this shortcut from Settings > Manage App Execution Aliases.` it could be that my git bash cant find python... I have miniconda installed any solution for this?
-     - hopefully this helps: https://coderefinery.org/installation/conda/#setting-path-to-conda-from-your-terminal-shell
+     - hopefully this helps: https://coderefinery.github.io/installation/conda/#setting-path-to-conda-from-your-terminal-shell
 
 
 115. I spaced out for a sec, what is `git revert -n master~..master~2` supposed to do?
@@ -795,13 +795,13 @@ https://coderefinery.org/git-intro/recovering/
 
 139. Could you paste where are we in the schedule? Will there be another exercise session?
      - no more exercise session
-     - after break we will discuss https://coderefinery.org/git-intro/staging-area/ and https://coderefinery.org/git-intro/level/
+     - after break we will discuss https://coderefinery.github.io/git-intro/staging-area/ and https://coderefinery.github.io/git-intro/level/
 
 140. In some cases this file <<.ingredients.txt.swp>> appears as unstagged. Why does this happen?
     - Usually, these `.*swp` are temporary files created by your editor. It tells "I am modifying this file, don't touch it". I usually gitignore them, i.e. write `*.swp` in `.gitignore`
 ---
 ### 1.4 Using the Git staging area
-https://coderefinery.org/git-intro/staging-area/
+https://coderefinery.github.io/git-intro/staging-area/
 
 
 141. Can you change the text of older commits?

--- a/content/questions/day3.md
+++ b/content/questions/day3.md
@@ -52,7 +52,7 @@ Second exercise:
 
 
 ## 1. git-collab - day 3
-https://coderefinery.org/git-collaborative/
+https://coderefinery.github.io/git-collaborative/
 
 ### Tip
 Command to test that your SSH keys are being used correctly: `ssh -T git@github.com`
@@ -64,7 +64,7 @@ Command to test that your SSH keys are being used correctly: `ssh -T git@github.
 
 2. Could we get a short overview of the exercises I need to prep as an exercise lead?
    - I'm not sure, but I think it is what is in the hackmd.  We can set it up during the course I think, that is part of it.
-   - here's a list of the exercises: https://coderefinery.org/git-collaborative/exercises/
+   - here's a list of the exercises: https://coderefinery.github.io/git-collaborative/exercises/
 
 3. Should we have followed along for pull request? I got distracted by hackmd.
    - No, that was just a preview.  No one had to watch it, everything will be said again during the course.
@@ -184,7 +184,7 @@ https://coderefinery.github.io/git-collaborative/
     - You need to have your repository visibility set to public in order to protect branches with a free account.
 
 ### Exercise: 
-https://coderefinery.org/git-collaborative/centralized/#exercise-part-1-creating-a-pull-request
+https://coderefinery.github.io/git-collaborative/centralized/#exercise-part-1-creating-a-pull-request
 
 33. Where is the recorded version link again? I signed up last night, and accepted the invitation this morning.
     - https://github.com/cr-workshop-exercises/centralized-workflow-exercise-recorded
@@ -219,7 +219,7 @@ https://coderefinery.org/git-collaborative/centralized/#exercise-part-1-creating
 
 
 ### EXERCISE #1 until xx:25 (at xx:15 we will start going over it on-stream)
-https://coderefinery.org/git-collaborative/centralized/#exercise-part-1-creating-a-pull-request
+https://coderefinery.github.io/git-collaborative/centralized/#exercise-part-1-creating-a-pull-request
 Do the exercise until **step 8** included.
 
 If you have time, you can also try Centralized-3 exercise where you first create an issue and cross-reference
@@ -270,7 +270,7 @@ it in the commit message or the pull request title or form.
     - Please make sure it's not a typo in the file name. Do `git status` and see if you can see there are modified changes for this file. Also, make sure you have initialized the local dir as a git repo. Done already if you `git clone...`
 
 51. What is step 8? In the exercise it seems that the setps are A to E
-    - https://coderefinery.org/git-collaborative/centralized/#exercise-part-1-creating-a-pull-request - sections numbered 1-8
+    - https://coderefinery.github.io/git-collaborative/centralized/#exercise-part-1-creating-a-pull-request - sections numbered 1-8
 
 52. In the website it says: 'The `-u` or `--set-upstream` will connect the local branch with the newly created upstream/remote branch and track it.' Can you explain what is meant by the "newly created upstream/remote branch"? Is upstream and remote the same word here 
     - Usage example: `git push -u origin branchname`. `-u` means "map the local branch `<branchname>` to the branch with the same name, but on the remote repository `origin`". This way, next time you do a `git push` of commits on the branch `branchname` it is enough if you specify `git push`.
@@ -554,7 +554,7 @@ https://coderefinery.github.io/git-collaborative/distributed/
      - Fork: GitHub concept for connected repos online ( forking tells github that you are creating a copy of a repository in your online github storage, and lets it know that they are connected)
      - Clone: Make a copy of a repo from GitHub to your computer (you could push this to an "empty" repository you have online, but then the link to the original repository would be lost)
      - (there are slightly more general)
-     - Also see the workshop section https://coderefinery.org/git-collaborative/remotes/#commits-branches-repositories-forks-clones with terminology
+     - Also see the workshop section https://coderefinery.github.io/git-collaborative/remotes/#commits-branches-repositories-forks-clones with terminology
 
 102. Can we fork from the command line?
      - Not using the basic Git installation. But if you have the GitHub comand-line interface (CLI) tools you may do that. If you do not fork very often, I would not install Git CLI. But others find it very useful, please comment.
@@ -589,7 +589,7 @@ https://coderefinery.github.io/git-collaborative/distributed/
 109. At some point you mentioned what was needed to get a certificate of attendance. Could you repeat where to find the requirements?
      - Workshop webpage
         - I tried searching the webpage, but could not find it. Could you post link?
-            - https://coderefinery.org/2022-03-22-workshop/#certificates-and-credits
+            - https://coderefinery.github.io/2022-03-22-workshop/#certificates-and-credits
 
 110. i got this error. remote: Permission to coderefinery/template-forking-workflow-exercise.git denied to [name]. So what should i do?
      fatal: unable to access 'https://github.com/coderefinery/template-forking-workflow-exercise/': The requested URL returned error: 403

--- a/content/questions/day4.md
+++ b/content/questions/day4.md
@@ -70,7 +70,7 @@ https://coderefinery.github.io/reproducible-research/
 https://coderefinery.github.io/reproducible-research/motivation/
 
 3. I could not spot the instructions to download and install Snakemake. Can you please direct to those?
-     - it is part of the Conda environment (https://coderefinery.org/installation/conda-environment/) so if you have installed that one, then you have snakemake
+     - it is part of the Conda environment (https://coderefinery.github.io/installation/conda-environment/) so if you have installed that one, then you have snakemake
          -  working with conda 4.12.0
  and snakemake is not listed in `conda list` alas
      - we will later also discuss what Conda environments are but if you want to see what is inside the one we provide: https://github.com/coderefinery/software/blob/main/environment.yml
@@ -269,7 +269,7 @@ which is not quite uniform as we may wish...
 
 
 37. Where do we find the .yml file we should create our new CodeRefinery environment from?+1
-     - Follow https://coderefinery.org/installation/conda-environment/
+     - Follow https://coderefinery.github.io/installation/conda-environment/
      - The file itself is actually here: https://github.com/coderefinery/software/blob/main/environment.yml
 
 38. Can we activate an environment without deactivating before or do we have to deactivate, then activate?+1
@@ -281,7 +281,7 @@ which is not quite uniform as we may wish...
 
 
 ### Exercises until xx:05, then break.
-### [Dependencies-2](https://coderefinery.org/reproducible-research/dependencies/#exercise-exploring-conda-environments)
+### [Dependencies-2](https://coderefinery.github.io/reproducible-research/dependencies/#exercise-exploring-conda-environments)
 
 Explore most commands there, if you can't finish it all there is no problem
 
@@ -290,7 +290,7 @@ done: oooooooooo
 need more time: ooooooo
 not trying: oo
 
-39. Why after doing [this step](https://coderefinery.org/installation/conda/#setting-conda-path), I cannot find my Anaconda Prompt anymore? And after some time, I have to do it again because git bash does not recognize 'conda' anymore. What could be the reason?
+39. Why after doing [this step](https://coderefinery.github.io/installation/conda/#setting-conda-path), I cannot find my Anaconda Prompt anymore? And after some time, I have to do it again because git bash does not recognize 'conda' anymore. What could be the reason?
     - I'm not sure, we would need to look.  Can we look later, or find someone local/in Zoom/etc to as''k?
     - I am not sure whats your problem exactly, but I realized that one has to be careful with the "conda init" command. it modifies the .bashrc file and comments the line with the export path command. Also, for some reason the conda activate command did not work for me (although `PATH` was set up correctly) and I needed to go to the env folder and use "source activate ...."
 
@@ -378,7 +378,7 @@ not trying: oo
     - If you have cloned the repository, don't worry.
     - No, I haven't. I lost the track there.
         - Go to https://github.com//coderefinery/word-count. Use the green "Use this template" button to create a repository. Then clone the new repository.
-        - steps also at https://coderefinery.org/reproducible-research/workflow-management/, in the Exercise preparation section
+        - steps also at https://coderefinery.github.io/reproducible-research/workflow-management/, in the Exercise preparation section
 
 > HPC: High Performance Computing 
 
@@ -518,7 +518,7 @@ I am:
 86. I needed to run `docker pull` as root, otherwise I got `permission denied`...
     - You can give permission to your user to do this (to be discussed later).  All these permission problems are one reason we don't have an exercise about this!
     - [Run Docker when not root](https://docs.docker.com/engine/security/rootless/)
-	- For more Docker material, see also [extra lesson](https://coderefinery.org/reproducible-research/docker/)
+	- For more Docker material, see also [extra lesson](https://coderefinery.github.io/reproducible-research/docker/)
 
 
 ---
@@ -537,7 +537,7 @@ https://coderefinery.github.io/reproducible-research/sharing/
     - Agree; on the other hand - if it's hosted in GitHub or similar platform, it should exist there "forever", shouldn't it?
 
 ### Exercise until xx:25
-[Sharing-1](https://coderefinery.org/reproducible-research/sharing/#exercise-connecting-repositories-to-zenodo)
+[Sharing-1](https://coderefinery.github.io/reproducible-research/sharing/#exercise-connecting-repositories-to-zenodo)
 Do what you can, no problem if you can't/run out of time.
 
 
@@ -597,7 +597,7 @@ Then social coding
 ---
 ## 2. [Social coding](https://coderefinery.github.io/social-coding/)
 
-### 2.1 [Social coding in general](https://coderefinery.org/social-coding/social_coding/)
+### 2.1 [Social coding in general](https://coderefinery.github.io/social-coding/social_coding/)
 
 
 ### Discussion: basics of sharing
@@ -701,9 +701,9 @@ What reasons are there to not share?
      - Yes. In particular sharing with your future you. Do it :-) I have lost access to some of my scripts because I accidentally deleted them or for license reasons.
 
 ---
-### 2.2 [Code reusability](https://coderefinery.org/social-coding/social_coding/#code-reusability)
+### 2.2 [Code reusability](https://coderefinery.github.io/social-coding/social_coding/#code-reusability)
 
-### Exercise: [Social-2](https://coderefinery.org/social-coding/social_coding/#what-contributes-to-reusability)
+### Exercise: [Social-2](https://coderefinery.github.io/social-coding/social_coding/#what-contributes-to-reusability)
 
 [Recipe repository](https://github.com/coderefinery/recipe)
 
@@ -729,7 +729,7 @@ What can be added to our recipe repository to make it more reusable?
      - correct. is it 70 years? same applies (depending on coutry) to software but let's see whether we can still compile and run the code we write today in 70 years. for books this is known territory but for software we are in a new territory here.
 
 
-### [Exercise: derivative works](https://coderefinery.org/social-coding/licensing/#derivative-work)
+### [Exercise: derivative works](https://coderefinery.github.io/social-coding/licensing/#derivative-work)
 
 1. Download some code from a website and add on to it
 2. Download some code and use one of the functions in your code
@@ -811,7 +811,7 @@ What can be added to our recipe repository to make it more reusable?
 124. How is a copyright automatically generated? Once you saved it as jupyter notebook or something else?
      - Whenever you write something, you have copyright to it. It does not need to be published in principle. However to prove that someone has infringed your copyright, you need to show they could have seen your work.
 
-### [Exercises: licensing](https://coderefinery.org/social-coding/licensing/#exercises-licensing)
+### [Exercises: licensing](https://coderefinery.github.io/social-coding/licensing/#exercises-licensing)
 
 **Licensing-2: Consider some common licensing situations**
 

--- a/content/questions/day5.md
+++ b/content/questions/day5.md
@@ -69,10 +69,10 @@ template = "page-with-toc.html"
 
 ---
 ## 1. Jupyter
-https://coderefinery.org/jupyter/version-control/
+https://coderefinery.github.io/jupyter/version-control/
 
 ### 1.1 Jupyter notebooks 
-https://coderefinery.org/jupyter/motivation/
+https://coderefinery.github.io/jupyter/motivation/
 
 1. I don't use python so far (planning to learn). Can we use jupyter for R? Or is it similar to R studio?
     - Yes, you can.  Many people use RStudio instead, but some of the Jupyter lesson here still applies (the Binder part might be especially useful)
@@ -94,7 +94,7 @@ https://coderefinery.org/jupyter/motivation/
 
 5. Where is the link to install jupyter? I saw it before, but can't find it now. 
     - Jupyter and JupyterLab are part of the CodeRefinery environment.yml file which was part of the installation instructions
-    - Instructions for creating the environment: https://coderefinery.org/installation/conda-environment/
+    - Instructions for creating the environment: https://coderefinery.github.io/installation/conda-environment/
 
 6. Can Jupyter be used for MATLAB codes or is there any alternative for that?
    - There is a MATLAB "kernel" that runs matlab code within Jupyter.
@@ -128,14 +128,14 @@ https://coderefinery.org/jupyter/motivation/
 
 ---
 ### 1.2 JupyterLab and notebook interface
-https://coderefinery.org/jupyter/interface/
+https://coderefinery.github.io/jupyter/interface/
 
 13. In my coderefinery environment, I get error with ´sphinx-build --version´. 
     `ImportError: cannot import name 'environmentfilter' from 'jinja2'`
     - I recognize this error. Give me a min to look for the workaround ...
     - Can you please try to find out what your sphinx version is? `sphinx-build --version` but that might fail. You can also try: `python -c "import sphinx; print(sphinx.__version__)"`
     - When did you make the enviornment? Did you make it from our environment.yml ?
-        - yes, it is the same environment that we used yesterday: https://coderefinery.org/installation/conda-environment/
+        - yes, it is the same environment that we used yesterday: https://coderefinery.github.io/installation/conda-environment/
           - sorry I forgot to follow up here. what sphinx version do you have?
 
 14. Why can't I see the CodeRefinery conda environment in JupyterLab? +1
@@ -144,7 +144,7 @@ https://coderefinery.org/jupyter/interface/
             - just a clarifying note to avoid confusion: `coderefinery` is an environment, `Python3` is the kernel in this case.
 
 15. (Im guessing this will be covered later but asking in case) What are the best practices/options for version control of Jupyter notebooks, when I started using them I noticed the git files became very large very fast
-    - `git` and `nbdime` is one solution. Other solutions are listed in a follow-up episode of the Jupyter lesson: https://coderefinery.org/jupyter/version-control/?highlight=nbdime
+    - `git` and `nbdime` is one solution. Other solutions are listed in a follow-up episode of the Jupyter lesson: https://coderefinery.github.io/jupyter/version-control/?highlight=nbdime
 
 16. How can I use a different environment when I have the JupyterLab tab opened?
     - You can install other *kernels* which are for other Python environments.  Looking...
@@ -167,7 +167,7 @@ https://coderefinery.org/jupyter/interface/
 				- Yeah, probably as you said.
 
 21. Where are the contents for this exercise, eg where is this markdown content copied from?
-    - Is it from here?: https://coderefinery.org/jupyter/interface/
+    - Is it from here?: https://coderefinery.github.io/jupyter/interface/
 
 22. I activated the coderefinery environment with conda but now I get the following message when trying to run jupyter-lab $ jupyter-lab
     ```failed to create process.```
@@ -197,13 +197,13 @@ https://coderefinery.org/jupyter/interface/
 
 ---
 ### 1.3 A first computational notebook
-https://coderefinery.org/jupyter/first-notebook/#a-first-computational-notebook
+https://coderefinery.github.io/jupyter/first-notebook/#a-first-computational-notebook
 
 #### Exercise until xx:49
 
-- https://coderefinery.org/jupyter/first-notebook/#an-example-computational-notebook
+- https://coderefinery.github.io/jupyter/first-notebook/#an-example-computational-notebook
 - Do what you can, nothing in the rest of the lesson depenends on this.
-- Optional exercises: Installing a kernel for your favorite language: https://coderefinery.org/jupyter/first-notebook/#notebooks-in-other-languages
+- Optional exercises: Installing a kernel for your favorite language: https://coderefinery.github.io/jupyter/first-notebook/#notebooks-in-other-languages
 
 
 26. Would you show the exercise on the twitch screen please? It saves me a window to look at...
@@ -251,7 +251,7 @@ https://coderefinery.org/jupyter/first-notebook/#a-first-computational-notebook
 
 ---
 ### 1.4 Notebooks and version control
-https://coderefinery.org/jupyter/version-control/
+https://coderefinery.github.io/jupyter/version-control/
 
 35. I usually use Jupyter notebook and not jupyter-lab. Are the things we go through now about version control the same for jupyter notebook?
     - Many are the same, the main difference is the user-interface.
@@ -419,7 +419,7 @@ git diff
 
 ---
 ### 1.5 Sharing notebooks
-https://coderefinery.org/jupyter/sharing/#sharing-notebooks
+https://coderefinery.github.io/jupyter/sharing/#sharing-notebooks
 
 66. I get `503 Service Temporarily Unavailable` when trying Binder +1+
     - Unfortunately binder has been a bit unstable today.
@@ -527,7 +527,7 @@ https://coderefinery.org/jupyter/sharing/#sharing-notebooks
     - People will often share the Github repo, and then the README has a link to binder (or whatever).  People can paste/clone the repository into whatever other service they want.
 
 
-83. How to make a page like "https://coderefinery.org/jupyter/extra-features/". Can it be done using github?
+83. How to make a page like "https://coderefinery.github.io/jupyter/extra-features/". Can it be done using github?
     - We are about to see in the upcoming documentation lesson!
     - But yes, this is git + Sphinx (next lesson) + Github Pages (next lesson).
 
@@ -548,10 +548,10 @@ https://coderefinery.org/jupyter/sharing/#sharing-notebooks
 
 ---
 ## 2. Documentation
-https://coderefinery.org/documentation/
+https://coderefinery.github.io/documentation/
 
 ### 2.1 Motivation and wishlist
-https://coderefinery.org/documentation/wishlist/#motivation-and-wishlist
+https://coderefinery.github.io/documentation/wishlist/#motivation-and-wishlist
 
 ### Poll
 
@@ -604,7 +604,7 @@ What would you like to see in the documentation of something you use?
 
 ---
 ### 2.2 Tools and solutions
-https://coderefinery.org/documentation/tools/#popular-tools-and-solutions
+https://coderefinery.github.io/documentation/tools/#popular-tools-and-solutions
 
 
 89. Any general guidelines what should always have docsrting and what not necessarily? I.e. I often found that all classes and some functions have them...+1 
@@ -613,14 +613,14 @@ https://coderefinery.org/documentation/tools/#popular-tools-and-solutions
 
 ---
 ### 2.3 In-code documentation
-https://coderefinery.org/documentation/in-code-documentation/#in-code-documentation
+https://coderefinery.github.io/documentation/in-code-documentation/#in-code-documentation
 
 Skipped, but feel free to go through the material above after the workshop. 
 
 ---
 ### 2.4 Writing readme files
 
-https://coderefinery.org/documentation/writing-readme-files/
+https://coderefinery.github.io/documentation/writing-readme-files/
 
 90. Do we *have* to scream `README`?
     - No, github does that automatically :smile:, but well. It is to some extent derived from too many people not reading the manual/readme. 
@@ -631,7 +631,7 @@ https://coderefinery.org/documentation/writing-readme-files/
 
 
 #### Exercises until xx:30
-https://coderefinery.org/documentation/writing-readme-files/#exercises
+https://coderefinery.github.io/documentation/writing-readme-files/#exercises
 
 Do exercises README-{1,2,3}, whatever interests you the most.
 
@@ -642,7 +642,7 @@ For getting **help in an exercise room**, please write the room name here or in 
 
 ---
 ### 2.5 Sphinx and Markdown
-https://coderefinery.org/documentation/sphinx/
+https://coderefinery.github.io/documentation/sphinx/
 
 91. When writing `sphinx-build --version `inside the coderefinery environment (already activated in conda), I get the following message: `bash: sphinx-build: command not found`
     - Try running `conda install sphinx
@@ -760,7 +760,7 @@ https://coderefinery.org/documentation/sphinx/
     
 114. How did you change the style to look like the CodeRefinery docs?
      - in `conf.py` look for "theme" and for the lessons we use one derived from `sphinx_rtd_theme` (the Read the Docs theme)
-     - Shameless advertisement: https://coderefinery.org/sphinx-lesson/ (but it's basically default sphinx featueres + sphinx_rtd_theme, nothing fancy here)
+     - Shameless advertisement: https://coderefinery.github.io/sphinx-lesson/ (but it's basically default sphinx featueres + sphinx_rtd_theme, nothing fancy here)
 
 
 114. Can you inlcude an exisiting html file in spinx? I'm reffering to an exisiting .html-page. Do you need to include anything in extensions and source_suffix (in conf.py)? 
@@ -790,7 +790,7 @@ https://coderefinery.org/documentation/sphinx/
 
 ---
 #### Exercises until xx:28
-https://coderefinery.org/documentation/sphinx/
+https://coderefinery.github.io/documentation/sphinx/
 Exercise Sphinx-2
 
 118. I did not quite understand the instruction after point 3, Experiment with the following Markdown syntax: (Thanks to hackMD, I can ask these kind of questions). What should we do at this step?
@@ -835,7 +835,7 @@ Exercise Sphinx-2
 
 125. I like the customized prompts in general; which tools do I use to do that?
      - This is a big topic, search the web and you can find plenty (or join our chat and find a particular instructor to ask)
-     - Some general info on what we do: https://coderefinery.org/manuals/instructor-tech-setup/ (but it hasn't been updated in a while)
+     - Some general info on what we do: https://coderefinery.github.io/manuals/instructor-tech-setup/ (but it hasn't been updated in a while)
 
 
 ---
@@ -877,7 +877,7 @@ Today was:
 - The README file example in breakout room works well only if all the attendees have experience with the same tool or are all used to python and can quickly read the given code. In our case none of these assumptions was verified, so it became a vague discussion mostly repeating what had been already stated in the main stream.
 - just as you had the exercise plan on top, maybe also write when breaks are planned?
 - How to publish the documentation, i.e. how to put the stuff generated by Sphinx into a real accessible website
-   - We had to skip this for time, but see https://coderefinery.org/documentation/gh_workflow/
+   - We had to skip this for time, but see https://coderefinery.github.io/documentation/gh_workflow/
    - EDIT: Thanks, I'll check that 
 - As mentioned above , say when type-along and when it is a demonstration. In fact, I would avoid demonstrations - we learn more if we do it too ( I appreaciate the time factor, but it is worth it to have less material but do it all in the type-along mode)
 - I can only speak for my group, but I would suggest revising the timing of the exercises (20 min for Jupyter notebook was too long; 10-15min for everything else was right/ could be longer )
@@ -886,7 +886,7 @@ Today was:
 #### Any other comments:
 - Please avoid highly customized prompts as they make it very difficult for users to see the analogy between their terminal and the one of the instructor. For example, Thor's prompt is very cool, indeed, but it increases the flow of information as well as the demands of interpretations for learners.+1
 
-- In the exercise https://coderefinery.org/documentation/gh_workflow/#exercise-deploy-sphinx-documentation-to-github-pages, there's a mistake in this step: "That’s it! Your site should now be live on `https://github.com/<myuser>/word-count/settings/pages` (replace username).". The link should be username.github.io/word-count/ 
+- In the exercise https://coderefinery.github.io/documentation/gh_workflow/#exercise-deploy-sphinx-documentation-to-github-pages, there's a mistake in this step: "That’s it! Your site should now be live on `https://github.com/<myuser>/word-count/settings/pages` (replace username).". The link should be username.github.io/word-count/ 
      - Thanks!
 
 

--- a/content/questions/day6.md
+++ b/content/questions/day6.md
@@ -59,7 +59,7 @@ template = "page-with-toc.html"
 https://coderefinery.github.io/testing/
 
 ### 1.1 Motivation
-https://coderefinery.org/testing/motivation/
+https://coderefinery.github.io/testing/motivation/
 
 2. There is a wonderful homepage on bugs in softwares (unfortunately only in german): https://www5.in.tum.de/persons/huckle/bugs.html 
    Probably Google-Translate helps
@@ -71,7 +71,7 @@ https://coderefinery.org/testing/motivation/
         - what does this mean ?
     - I would add test for a function before rewriting it. Or right after I solved a difficult bug in it to make sure it does not come back.
 
-4. C++ code at https://coderefinery.org/testing/motivation/, what is there a specific reason to `return EXIT_SUCCESS;` instead of `return 0;` in `main()`?
+4. C++ code at https://coderefinery.github.io/testing/motivation/, what is there a specific reason to `return EXIT_SUCCESS;` instead of `return 0;` in `main()`?
     - I think just clarity. `EXIT_SUCCESS` is `0`, but if the reader does not know the convention they can still guess `EXIT_SUCCESS` means
     - Possibly on some system the success code is not 0?
 
@@ -123,7 +123,7 @@ https://coderefinery.org/testing/motivation/
 
 ----
 ### 1.2 Concepts
-https://coderefinery.org/testing/concepts/#concepts
+https://coderefinery.github.io/testing/concepts/#concepts
 
 9. If I want to test a function that gets as input a dataset, to test it I will have to have a whole test dataset?
     - for this it's good to have very small toy/testset datasets, yes! depends on whether you're talking about a data loading function (from disk; e.g. can it handle special cases? one-entry datasets? zero-entry?), or just a function that gets data (e.g. a numpy array)
@@ -139,7 +139,7 @@ https://coderefinery.org/testing/concepts/#concepts
 
 ---
 ### 1.3 Testing locally 
-https://coderefinery.org/testing/pytest/
+https://coderefinery.github.io/testing/pytest/
 
 
 12. Is pytest something from the developers of python or an external library?
@@ -169,7 +169,7 @@ https://coderefinery.org/testing/pytest/
 ---
 #### Exercise until xx:49
 Exercise Local-1
-https://coderefinery.org/testing/pytest/#exercise-pytest
+https://coderefinery.github.io/testing/pytest/#exercise-pytest
 
 17. What's the purpose of having multiple assert, does order matter?
     - Great question. It will fail on the first failing one. And maybe it would be better to not package multiple asserts into the same test so that we can see all failures and not only the first one.
@@ -203,7 +203,7 @@ https://coderefinery.org/testing/pytest/#exercise-pytest
       - in `vim`, I believe adding `syntax on` to your `~/.vimrc` could work.
 
 22. My understanding is that `pyTest` is tool for debugging python script. What if I want to debug script written in other languagues, e.g., `C++?`
-    - There is a list of tools in the course material at https://coderefinery.org/testing/quick-reference/
+    - There is a list of tools in the course material at https://coderefinery.github.io/testing/quick-reference/
     - If your language is not on the list, search the web for "unit testing framework" + language. Or write functions that run a function, check the output and error if it's wrong.
 
 23. How do you test, for example, data filtering functions? Or other more complex functions which you don't always know the results of? 
@@ -257,14 +257,14 @@ https://coderefinery.org/testing/pytest/#exercise-pytest
 
 ---
 ### 1.4 Automated testing
-https://coderefinery.org/testing/continuous-integration/#automated-testing
+https://coderefinery.github.io/testing/continuous-integration/#automated-testing
 
 32. Sorry, "follow the screen" == "type-along" or not? +1
     - `assert("follow the screen" == "type-along")` what is the answer? The webpage says "Type-along exercise".
     - Johan says please watch only.
 
 32. Aaah, where did he press???
--  https://coderefinery.org/testing/continuous-integration/#step-3-enable-automated-testing
+-  https://coderefinery.github.io/testing/continuous-integration/#step-3-enable-automated-testing
     - It somehow looks different in my github. i dont see the button
         - Could it be because you resized the brower's window?
             - No, there are several suggested options below, but not the button he had
@@ -309,7 +309,7 @@ https://coderefinery.org/testing/continuous-integration/#automated-testing
            - It can also be good if you want to get a review from someone else before merging.
 
 42. Would be nice to see the .yaml file again I think.
-    - You can see the default at https://coderefinery.org/testing/continuous-integration/
+    - You can see the default at https://coderefinery.github.io/testing/continuous-integration/
     - Thanks!
     - So you have to update it with the names of the branches that you gradually create, right? And then update it again when the branches are deleted?
         - The yaml has 
@@ -334,7 +334,7 @@ https://coderefinery.org/testing/continuous-integration/#automated-testing
 
 ---
 ### 1.5 Test design
-https://coderefinery.org/testing/test-design/
+https://coderefinery.github.io/testing/test-design/
 
 **Demo only, just watch and enjoy**
 
@@ -368,7 +368,7 @@ This uses Julia as an example language but applies to any language.  You should 
 
 ---
 #### Pathfinding 
-The fizzbuzz exercise is at https://coderefinery.org/testing/test-design/#test-driven-development
+The fizzbuzz exercise is at https://coderefinery.github.io/testing/test-design/#test-driven-development
 
 55. Use the modulus function (for dividing by 3 or 5). ;)
 
@@ -468,10 +468,10 @@ The fizzbuzz exercise is at https://coderefinery.org/testing/test-design/#test-d
 
 ---
 ##  2. Modular code development
-https://coderefinery.org/modular-type-along/
+https://coderefinery.github.io/modular-type-along/
 
 ### 2.1 Starting questions
-https://coderefinery.org/modular-type-along/questions/
+https://coderefinery.github.io/modular-type-along/questions/
 
 #### **What does “modular code development” mean for you?**
 - Organising your code, such that similar functionality is grouped and that individual parts can be used without the necessity to load everything. +1
@@ -566,11 +566,11 @@ https://coderefinery.org/modular-type-along/questions/
 
 ---
 ### 2.2 Learning topics
-https://coderefinery.org/modular-type-along/learning-outcomes/
+https://coderefinery.github.io/modular-type-along/learning-outcomes/
 
 ---
 ### 2.3 Our task
-https://coderefinery.org/modular-type-along/lesson/
+https://coderefinery.github.io/modular-type-along/lesson/
 
 72. Shitty weather in helsinki. If it snows one more time I am starting to cry
     - Are the palms on the beach shivering out of the cold?
@@ -787,7 +787,7 @@ This is even a standard for the output of test frameworks: find a bit more in ht
     
 
 125. Can you post the link to the command line interface instructor note?
-     - https://coderefinery.org/modular-type-along/instructor-guide/#command-line-interface
+     - https://coderefinery.github.io/modular-type-along/instructor-guide/#command-line-interface
      - Thank you!
 
 126. Is it possible to provide another course focusing on tn the materials of the second week with more details? like coderefinary.v2. covering more test, reproducibility and collaborative coding. another 6 sessions. +1 +1 +1


### PR DESCRIPTION
- To handle the canonical URLs (if we move back)
- Review: check that I didn't convert anything that didn't need to (or
  not, I did check when replacing but it could be wrong, still
  probably good enough for now)
